### PR TITLE
fix artifact name for sha265sum check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN set -x \
     file
 RUN export ARTIFACT="rke2.linux-amd64" \
  && curl --output ${ARTIFACT}  --fail --location https://github.com/rancher/rke2/releases/download/${TAG}/${ARTIFACT} \
- && grep -E " rke2.*" sha256sum-${ARCH}.txt | sha256sum -c \
+ && grep "rke2.linux-amd64$" sha256sum-${ARCH}.txt | sha256sum -c \
  && mv -vf ${ARTIFACT} /opt/rke2 \
  && chmod +x /opt/rke2 \
  && file /opt/rke2


### PR DESCRIPTION
This pr fixes the CI script for incorrect SHA265sum check after artifacts changed in rke2 original repo
issue : https://github.com/rancher/rke2/issues/286