### PR TITLE
fix rke2 is not running on this server error when rke2 is installed via rpm

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -12,9 +12,9 @@ fatal()
 }
 
 get_rke2_process_info() {
-  rke2_PID=$(ps -ef | grep -E "/usr/local/bin/rke2 .*(server|agent)" | grep -E -v "(init|grep)" | awk '{print $1}')
+  rke2_PID=$(ps -ef | grep -E "/usr(/local)*/bin/rke2 .*(server|agent)" | grep -E -v "(init|grep)" | awk '{print $1}')
   if [ -z "$rke2_PID" ]; then
-    fatal "rke2 is not running on this server"
+      fatal "rke2 is not running on this server"
   fi
   info "rke2 binary is running with pid $rke2_PID"
   rke2_BIN_PATH=$(cat /host/proc/${rke2_PID}/cmdline | awk '{print $1}' | head -n 1)

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -14,7 +14,7 @@ fatal()
 get_rke2_process_info() {
   rke2_PID=$(ps -ef | grep -E "/usr(/local)*/bin/rke2 .*(server|agent)" | grep -E -v "(init|grep)" | awk '{print $1}')
   if [ -z "$rke2_PID" ]; then
-      fatal "rke2 is not running on this server"
+    fatal "rke2 is not running on this server"
   fi
   info "rke2 binary is running with pid $rke2_PID"
   rke2_BIN_PATH=$(cat /host/proc/${rke2_PID}/cmdline | awk '{print $1}' | head -n 1)


### PR DESCRIPTION
### Problem:
The default lookup place for rke2_PID is /usr/local/bin,so when rke2 is installed using rpm, the upgrade fails with error message
"rke2 is not running on this server"

### Solution:
Check if rke2 is process is running in /usr/bin instead of /usr/local/bin
issue: https://github.com/rancher/rke2/issues/359