### PR TITLE
Also kill containerd/kubelet child pids when upgrading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN export ARTIFACT="rke2.linux-amd64" \
 
 RUN set -x \
  && apk --no-cache add curl \
- && curl -fsSLO https://storage.googleapis.com/kubernetes-release/release/v1.18.4/bin/linux/${ARCH}/kubectl \
+ && export K8S_RELEASE=$(echo ${TAG} | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+') \
+ && curl -fsSLO https://storage.googleapis.com/kubernetes-release/release/${K8S_RELEASE}/bin/linux/${ARCH}/kubectl \
  && chmod +x kubectl
 
 FROM ${ALPINE}

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -60,8 +60,9 @@ ensure_home_env() {
 kill_rke2_process() {
     # the script sends SIGTERM to the process and let the supervisor
     # to automatically restart rke2 with the new version
-    kill -SIGTERM $RKE2_PID
-    info "Successfully Killed old rke2 process $RKE2_PID"
+    CHILD_PIDS=$(pgrep -lP $RKE2_PID | grep -Eo '[0-9]+ (containerd|kubelet)' | awk 'BEGIN{ORS=" "}{print $1}')
+    kill -SIGTERM $RKE2_PID $CHILD_PIDS
+    info "Successfully Killed old rke2 process $RKE2_PID and containerd/kubelet processes $CHILD_PIDS"
 }
 
 prepare() {


### PR DESCRIPTION
Also kill containerd/kubelet child pids when upgrading. This is a workaround for rancher/rke2#828 - since the SUC only upgrades the rke2 binary itself, we can't count on having the fix from rancher/rke2#829 in place.

This also upgrades the kubectl binary based on the RKE2 tag to prevent issues with client-server version incompatibility.