### PR TITLE
Fix grep always failing

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -53,7 +53,7 @@ ensure_home_env() {
   FULL_SYSTEM_PATH="/host$RKE2_BIN_DIR/../lib/systemd/system/"
   for C in server agent; do
     ENV_FILE_PATH="$FULL_SYSTEM_PATH/rke2-$C.env"
-    grep -sq $ENV_FILE_PATH '^HOME=' || echo -e "\nHOME=/root" >> $ENV_FILE_PATH
+    grep -sq '^HOME=' $ENV_FILE_PATH || echo -e "\nHOME=/root" >> $ENV_FILE_PATH
   done
 }
 


### PR DESCRIPTION
The arguments to grep are 1: pattern, 2: path. This was inversed and caused the script to always write a new line.

Proof:
![image](https://github.com/rancher/rke2-upgrade/assets/45149055/2991c523-bb00-4071-b7ca-c967ef024d5c)
