### PR TITLE
Remove conditional in `release.yaml` workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,6 @@ jobs:
 
     - name: Publish Image - Staging
       uses: rancher/ecm-distro-tools/actions/publish-image@master
-      if: ${{ contains(github.ref_name, '-rc') }}
       env:
         TAG: ${{ github.ref_name }}
         ARCH: ${{ matrix.arch }}
@@ -147,7 +146,6 @@ jobs:
 
       - name: Publish Manifest - Staging
         uses: rancher/ecm-distro-tools/actions/publish-image@master
-        if: ${{ contains(github.ref_name, '-rc') }}
         with:
           image: ${{ env.IMAGE }}
           tag: ${{ env.GIT_TAG }}
@@ -161,7 +159,6 @@ jobs:
           prime-password: ${{ env.PRIME_STAGING_REGISTRY_PASSWORD }}
 
       - name: Inspect Staging image
-        if: ${{ contains(github.ref_name, '-rc') }}
         run: docker buildx imagetools inspect ${{ env.PRIME_STAGING_REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE }}:${{ env.GIT_TAG }}
 
       - name: Publish Image - Prime


### PR DESCRIPTION
The current logic doesn't publish GA images to the Staging Registry, with this change it will allow both RC and GA images to be published there.